### PR TITLE
Another strategy for onTap() and refresh result in onShow() 

### DIFF
--- a/source/views/BeginnerView.mc
+++ b/source/views/BeginnerView.mc
@@ -3,6 +3,10 @@ using Toybox.Graphics as Gfx;
 using Toybox.System as Sys;
 using Toybox.Math as Math;
 
+var random = null;
+var opponent = null;
+var you = null;
+
 class BeginnerView extends Ui.View {
 
 	//! Load your resources here
@@ -12,22 +16,19 @@ class BeginnerView extends Ui.View {
 
 	//! Restore the state of the app and prepare the view to be shown
 	function onShow() {
+		random = findDrawableById("beginner_random");
+		opponent = findDrawableById("beginner_opponent");
+		you = findDrawableById("beginner_you");
 	}
 
-	//! Called when this View is removed from the screen. Save the
-	//! state of your app here.
 	function onHide() {
+		random = null;
+		opponent = null;
+		you = null;
 	}
-
 }
 
 class BeginnerViewDelegate extends Ui.BehaviorDelegate {
-
-	hidden var view;
-
-	function initialize(view) {
-		self.view = view;
-	}
 
 	function manageRandomChoice() {
 		var beginner = Math.rand() % 2 == 0 ? :player_1 : :player_2;
@@ -65,20 +66,20 @@ class BeginnerViewDelegate extends Ui.BehaviorDelegate {
 
 	function onBack() {
 		//return to type screen
-		var view = new TypeView();
-		Ui.switchToView(view, new TypeViewDelegate(view), Ui.SLIDE_IMMEDIATE);
+		Ui.switchToView(new TypeView(), new TypeViewDelegate(), Ui.SLIDE_IMMEDIATE);
 		return true;
 	}
 
 	function onTap(event) {
-		var random = view.findDrawableById("beginner_random");
-		var opponent = view.findDrawableById("beginner_opponent");
-		var you = view.findDrawableById("beginner_you");
+		if (random == null || opponent == null || you == null) {
+			return false;
+		}
+
 		var tapped = UIHelpers.findTappedDrawable(event, [random, opponent, you]);
-		if("beginner_opponent".equals(tapped.identifier)) {
+		if(opponent.identifier == tapped.identifier) {
 			manageChoice(:player_2);
 		}
-		else if("beginner_you".equals(tapped.identifier)) {
+		else if(beginner.identifier == tapped.identifier) {
 			manageChoice(:player_1);
 		}
 		else {

--- a/source/views/MatchView.mc
+++ b/source/views/MatchView.mc
@@ -21,10 +21,6 @@ class MatchView extends Ui.View {
 		boundaries = getFieldBoundaries();
 	}
 
-	//! Load your resources here
-	function onLayout(dc) {
-	}
-
 	//! Restore the state of the app and prepare the view to be shown
 	function onShow() {
 		timer.start(method(:onTimer), 1000, true);
@@ -205,8 +201,7 @@ class MatchViewDelegate extends Ui.BehaviorDelegate {
 		}
 		else {
 			//return to beginner screen if match has not started yet
-			var view = new BeginnerView();
-			Ui.switchToView(view, new BeginnerViewDelegate(view), Ui.SLIDE_IMMEDIATE);
+			Ui.switchToView(new BeginnerView(), new BeginnerViewDelegate(), Ui.SLIDE_IMMEDIATE);
 		}
 		return true;
 	}

--- a/source/views/ResultView.mc
+++ b/source/views/ResultView.mc
@@ -10,17 +10,7 @@ class ResultView extends Ui.View {
 	}
 
 	//! Restore the state of the app and prepare the view to be shown
-	function onShow() {
-	}
-
-	//! Called when this View is removed from the screen. Save the
-	//! state of your app here.
-	function onHide() {
-	}
-
-	//! Update the view
-	function onUpdate(dc) {
-		View.onUpdate(dc);
+	function onShow(dc) {
 		//draw end of match text
 		var winner = match.getWinner();
 		var won_text = Ui.loadResource(winner == :player_1 ? Rez.Strings.end_you_won : Rez.Strings.end_opponent_won);
@@ -40,8 +30,7 @@ class ResultViewDelegate extends Ui.BehaviorDelegate {
 	function onKey(key) {
 		if(key.getKey() == Ui.KEY_ENTER) {
 			//return to type screen
-			var view = new TypeView();
-			Ui.switchToView(view, new TypeViewDelegate(view), Ui.SLIDE_IMMEDIATE);
+			Ui.switchToView(new TypeView(), new TypeViewDelegate(), Ui.SLIDE_IMMEDIATE);
 			return true;
 		}
 		return false;

--- a/source/views/TypeView.mc
+++ b/source/views/TypeView.mc
@@ -2,31 +2,28 @@ using Toybox.WatchUi as Ui;
 using Toybox.Graphics as Gfx;
 using Toybox.System as Sys;
 
+var single = null;
+var double = null;
+
 class TypeView extends Ui.View {
 
 	//! Load your resources here
 	function onLayout(dc) {
 		setLayout(Rez.Layouts.type(dc));
 	}
-
 	//! Restore the state of the app and prepare the view to be shown
 	function onShow() {
+		var single = view.findDrawableById("type_single");
+		var double = view.findDrawableById("type_double");
 	}
 
-	//! Called when this View is removed from the screen. Save the
-	//! state of your app here.
 	function onHide() {
+		single = null;
+		double = null;
 	}
-
 }
 
 class TypeViewDelegate extends Ui.BehaviorDelegate {
-
-	hidden var view;
-
-	function initialize(view) {
-		self.view = view;
-	}
 
 	function manageChoice(type) {
 		var app = Application.getApp();
@@ -35,8 +32,7 @@ class TypeViewDelegate extends Ui.BehaviorDelegate {
 
 		match = new Match(type, mp, amp);
 		match.listener = app;
-		var view = new BeginnerView();
-		Ui.switchToView(view, new BeginnerViewDelegate(view), Ui.SLIDE_IMMEDIATE);
+		Ui.switchToView(new BeginnerView(), new BeginnerViewDelegate(), Ui.SLIDE_IMMEDIATE);
 	}
 
 	function onNextPage() {
@@ -52,10 +48,12 @@ class TypeViewDelegate extends Ui.BehaviorDelegate {
 	}
 
 	function onTap(event) {
-		var single = view.findDrawableById("type_single");
-		var double = view.findDrawableById("type_double");
+		if (single == null || double == null) {
+			return false;
+		}
+
 		var tapped = UIHelpers.findTappedDrawable(event, [single, double]);
-		if("type_single".equals(tapped.identifier)) {
+		if(single.identifier == tapped.identifier) {
 			manageChoice(:single);
 		}
 		else {


### PR DESCRIPTION
also remove empty functions, so that the super class functions get called.

This fixes the glitch of the match result not shown in the end in the simulator. Might also fix some VivoActive bugs.